### PR TITLE
Add 2captcha softId

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The easiest way to quickly integrate [2Captcha] into your code to automate solvi
     - [report](#report)
   - [Proxies](#proxies)
   - [Error handling](#error-handling)
+  - [Useful links](#useful-links)
 
 ## Installation
 Install nuget package from [nuget]
@@ -392,10 +393,12 @@ catch (TimeoutException e)
     // captcha is not solved so far
 }
 ```
-[nuget]: https://www.nuget.org/packages/2captcha-csharp/
-[2Captcha]: https://2captcha.com/
-[2captcha sofware catalog]: https://2captcha.com/software
-[pingback settings]: https://2captcha.com/setting/pingback
-[post options]: https://2captcha.com/2captcha-api#normal_post
-[list of supported languages]: https://2captcha.com/2captcha-api#language
-[examples directory]: /TwoCaptcha.Examples
+
+## Useful links
+- [nuget](https://www.nuget.org/packages/2captcha-csharp/)
+- [2Captcha](https://2captcha.com/)
+- [2captcha sofware catalog](https://2captcha.com/software)
+- [Pingback settings](https://2captcha.com/setting/pingback)
+- [Post options](https://2captcha.com/2captcha-api#normal_post)
+- [list of supported languages](https://2captcha.com/2captcha-api#language)
+- [Examples directory](./TwoCaptcha.Examples)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The easiest way to quickly integrate [2Captcha] into your code to automate solvi
     - [send / getResult](#send--getresult)
     - [balance](#balance)
     - [report](#report)
+  - [Proxies](#proxies)
   - [Error handling](#error-handling)
 
 ## Installation
@@ -354,6 +355,16 @@ Use this method to report good or bad captcha answer.
 await solver.Report(captcha.Id, true); // captcha solved correctly
 await solver.Report(captcha.Id, false); // captcha solved incorrectly
 ```
+## Proxies
+
+You can pass your proxy as an additional argument for methods: recaptcha, funcaptcha, geetest, geetest v4, hcaptcha, keycaptcha, capy puzzle, lemin, turnstile, amazon waf and etc. The proxy will be forwarded to the API to solve the captcha.
+
+We have our own proxies that we can offer you. [Buy residential proxies](https://2captcha.com/proxy/residential-proxies) for avoid restrictions and blocks. [Quick start](https://2captcha.com/proxy?openAddTrafficModal=true).
+
+```csharp
+captcha.SetProxy("HTTPS", "login:password@IP_address:PORT");
+```
+
 
 ## Error handling
 If case of an error captcha solver throws an exception. It's important to properly handle these cases. We recommend to use `try catch` to handle exceptions.

--- a/TwoCaptcha.Tests/AmazonWafTest.cs
+++ b/TwoCaptcha.Tests/AmazonWafTest.cs
@@ -23,6 +23,7 @@ namespace TwoCaptcha.Tests
             parameters["pageurl"] = "https://non-existent-example.execute-api.us-east-1.amazonaws.com";
             parameters["context"] = "test_iv";
             parameters["iv"] = "test_context";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/AudioTest.cs
+++ b/TwoCaptcha.Tests/AudioTest.cs
@@ -27,6 +27,7 @@ namespace TwoCaptcha.Tests
             parameters["method"] = "audio";
             parameters["lang"] = "en";
             parameters["body"] = base64EncodedImage;
+            parameters["soft_id"] = "4582";
 
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);

--- a/TwoCaptcha.Tests/CanvasTest.cs
+++ b/TwoCaptcha.Tests/CanvasTest.cs
@@ -30,6 +30,7 @@ namespace TwoCaptcha.Tests
             parameters["recaptcha"] = "1";
             parameters["canvas"] = "1";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -50,6 +51,7 @@ namespace TwoCaptcha.Tests
             parameters["canvas"] = "1";
             parameters["body"] = "...";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -76,6 +78,7 @@ namespace TwoCaptcha.Tests
             parameters["can_no_answer"] = "0";
             parameters["lang"] = "en";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;

--- a/TwoCaptcha.Tests/CapyTest.cs
+++ b/TwoCaptcha.Tests/CapyTest.cs
@@ -21,6 +21,7 @@ namespace TwoCaptcha.Tests
             parameters["captchakey"] = "PUZZLE_Abc1dEFghIJKLM2no34P56q7rStu8v";
             parameters["pageurl"] = "http://mysite.com/";
             parameters["api_server"] = "https://myapiserver.com/";
+            parameters["soft_id"] = "4582";
 
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);

--- a/TwoCaptcha.Tests/CoordinatesTest.cs
+++ b/TwoCaptcha.Tests/CoordinatesTest.cs
@@ -24,6 +24,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["coordinatescaptcha"] = "1";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -42,6 +43,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["coordinatescaptcha"] = "1";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -59,6 +61,7 @@ namespace TwoCaptcha.Tests
             parameters["method"] = "base64";
             parameters["coordinatescaptcha"] = "1";
             parameters["body"] = "...";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -80,6 +83,7 @@ namespace TwoCaptcha.Tests
             parameters["coordinatescaptcha"] = "1";
             parameters["lang"] = "en";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;

--- a/TwoCaptcha.Tests/FunCaptchaTest.cs
+++ b/TwoCaptcha.Tests/FunCaptchaTest.cs
@@ -25,6 +25,7 @@ namespace TwoCaptcha.Tests
             parameters["surl"] = "https://client-api.arkoselabs.com";
             parameters["userAgent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36";
             parameters["data[anyKey]"] = "anyStringValue";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/GeeTestTest.cs
+++ b/TwoCaptcha.Tests/GeeTestTest.cs
@@ -23,6 +23,7 @@ namespace TwoCaptcha.Tests
             parameters["api_server"] = "api-na.geetest.com";
             parameters["challenge"] = "69A21A01-CC7B-B9C6-0F9A-E7FA06677FFC";
             parameters["pageurl"] = "https://launches.endclothing.com/distil_r_captcha.html";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/GeeTestV4Test.cs
+++ b/TwoCaptcha.Tests/GeeTestV4Test.cs
@@ -21,6 +21,7 @@ namespace TwoCaptcha.Tests
             parameters["captcha_id"] = "72bf15796d0b69c43867452fea615052";
             parameters["challenge"] = "12345678abc90123d45678ef90123a456b";
             parameters["pageurl"] = "https://mysite.com/captcha.html";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/GridTest.cs
+++ b/TwoCaptcha.Tests/GridTest.cs
@@ -23,6 +23,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["recaptcha"] = "1";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -41,6 +42,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["recaptcha"] = "1";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -58,6 +60,7 @@ namespace TwoCaptcha.Tests
             parameters["method"] = "base64";
             parameters["body"] = "...";
             parameters["recaptcha"] = "1";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -87,6 +90,7 @@ namespace TwoCaptcha.Tests
             parameters["can_no_answer"] = "0";
             parameters["lang"] = "en";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;

--- a/TwoCaptcha.Tests/HCaptchaTest.cs
+++ b/TwoCaptcha.Tests/HCaptchaTest.cs
@@ -21,6 +21,7 @@ namespace TwoCaptcha.Tests
             parameters["sitekey"] = "f1ab2cdefa3456789012345b6c78d90e";
             parameters["pageurl"] = "https://www.site.com/page/";
             parameters["data"] = "foo";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/KeyCaptchaTest.cs
+++ b/TwoCaptcha.Tests/KeyCaptchaTest.cs
@@ -25,6 +25,7 @@ namespace TwoCaptcha.Tests
             parameters["s_s_c_web_server_sign"] = "9006dc725760858e4c0715b835472f22-pz-";
             parameters["s_s_c_web_server_sign2"] = "2ca3abe86d90c6142d5571db98af6714";
             parameters["pageurl"] = "https://www.keycaptcha.ru/demo-magnetic/";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/LeminTest.cs
+++ b/TwoCaptcha.Tests/LeminTest.cs
@@ -21,6 +21,7 @@ namespace TwoCaptcha.Tests
             parameters["captcha_id"] = "CROPPED_d3d4d56_73ca4008925b4f83a8bed59c2dd0df6d";
             parameters["api_server"] = "api.leminnow.com";
             parameters["pageurl"] = "http://sat2.aksigorta.com.tr";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/NormalTest.cs
+++ b/TwoCaptcha.Tests/NormalTest.cs
@@ -23,6 +23,7 @@ namespace TwoCaptcha.Tests
 
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -40,6 +41,7 @@ namespace TwoCaptcha.Tests
 
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;
@@ -56,6 +58,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "base64";
             parameters["body"] = "...";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -88,6 +91,7 @@ namespace TwoCaptcha.Tests
             parameters["calc"] = "0";
             parameters["lang"] = "en";
             parameters["textinstructions"] = hintText;
+            parameters["soft_id"] = "4582";
 
             var files = new Dictionary<string, FileInfo>();
             files["file"] = image;

--- a/TwoCaptcha.Tests/ReCaptchaTest.cs
+++ b/TwoCaptcha.Tests/ReCaptchaTest.cs
@@ -28,6 +28,7 @@ namespace TwoCaptcha.Tests
             parameters["action"] = "verify";
             parameters["domain"] = "recaptcha.net";
             parameters["data-s"] = "foo";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -51,6 +52,7 @@ namespace TwoCaptcha.Tests
             parameters["action"] = "verify";
             parameters["min_score"] = "0.3";
             parameters["domain"] = "recaptcha.net";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/RotateTest.cs
+++ b/TwoCaptcha.Tests/RotateTest.cs
@@ -31,6 +31,7 @@ namespace TwoCaptcha.Tests
             parameters["lang"] = "en";
             parameters["textinstructions"] = "Put the images in the correct way up";
             parameters["body"] = base64EncodedImage;
+            parameters["soft_id"] = "4582";
 
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);

--- a/TwoCaptcha.Tests/TextTest.cs
+++ b/TwoCaptcha.Tests/TextTest.cs
@@ -18,6 +18,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["textcaptcha"] = question;
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -31,6 +32,7 @@ namespace TwoCaptcha.Tests
             var parameters = new Dictionary<string, string>();
             parameters["method"] = "post";
             parameters["textcaptcha"] = question;
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }
@@ -46,6 +48,7 @@ namespace TwoCaptcha.Tests
             parameters["method"] = "post";
             parameters["textcaptcha"] = question;
             parameters["lang"] = "en";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/TurnstileTest.cs
+++ b/TwoCaptcha.Tests/TurnstileTest.cs
@@ -25,6 +25,7 @@ namespace TwoCaptcha.Tests
             parameters["data"] = "foo";
             parameters["pagedata"] = "bar";
             parameters["action"] = "baz";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha.Tests/YandexTest.cs
+++ b/TwoCaptcha.Tests/YandexTest.cs
@@ -19,6 +19,7 @@ namespace TwoCaptcha.Tests
             parameters["method"] = "yandex";
             parameters["sitekey"] = "Y5Lh0tiycconMJGsFd3EbbuNKSp1yaZESUOIHfeV";
             parameters["pageurl"] = "https://rutube.ru";
+            parameters["soft_id"] = "4582";
 
             await CheckIfCorrectParamsSendAndResultReturned(captcha, parameters);
         }

--- a/TwoCaptcha/TwoCaptcha.cs
+++ b/TwoCaptcha/TwoCaptcha.cs
@@ -21,7 +21,7 @@ namespace TwoCaptcha
          * ID of software developer. Developers who integrated their software
          * with our service get reward: 10% of spendings of their software users.
          */
-        public int SoftId { get; set; }
+        public int SoftId { get; set; } = 4582;
 
         /**
          * URL to which the result will be sent


### PR DESCRIPTION
### What is done:
- Add default `soft_id=4582`
- Update tests
- Add information about **Proxy** to `README.md`
- Add the 'Useful links' section, fix the links in `README.md` (previously the links were not displayed because they were not correct)

Screenshot - Test execution completed successfully:
![image](https://github.com/2captcha/2captcha-csharp/assets/38065632/e7e10307-e032-484b-9483-a99c6dac6549)
