### PR TITLE
Changed .net version to single .netstandard

### DIFF
--- a/TwoCaptcha.Examples/TwoCaptcha.Examples.csproj
+++ b/TwoCaptcha.Examples/TwoCaptcha.Examples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard20</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/TwoCaptcha.Tests/TwoCaptcha.Tests.csproj
+++ b/TwoCaptcha.Tests/TwoCaptcha.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/TwoCaptcha/TwoCaptcha.csproj
+++ b/TwoCaptcha/TwoCaptcha.csproj
@@ -7,7 +7,7 @@
         <Company>2captcha</Company>
     </PropertyGroup>
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard20</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <None Include="..\README.md" pack="true" PackagePath="." />


### PR DESCRIPTION
Changed main library .net version into a single .netstandard2.0 to support all range of frameworks from modern to .net472.
All tests pass.